### PR TITLE
Fix compatibility for Debian 11 / OMV6

### DIFF
--- a/usr/sbin/wakealarm
+++ b/usr/sbin/wakealarm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 
 


### PR DESCRIPTION
python (2) is deprecated in Debian 11 and python3 is required.

Simple and easy fix.

All you need is to update the changelog :)

